### PR TITLE
Added config parameters to font loading functions

### DIFF
--- a/src/hello_imgui/imgui_default_settings.cpp
+++ b/src/hello_imgui/imgui_default_settings.cpp
@@ -12,59 +12,45 @@
 
 namespace HelloImGui
 {
-ImFont* LoadFontTTF(const std::string & fontFilename, float fontSize, bool useFullGlyphRange)
+ImFont* LoadFontTTF(const std::string & fontFilename, float fontSize, bool useFullGlyphRange, ImFontConfig config)
 {
     AssetFileData fontData = LoadAssetFileData(fontFilename.c_str());
 
-    auto makeFontConfig = [useFullGlyphRange]() {
-      auto r = ImFontConfig();
-      r.FontDataOwnedByAtlas = false;
-      if (useFullGlyphRange)
-      {
+    config.FontDataOwnedByAtlas = false;
+    if (useFullGlyphRange) {
         static ImWchar glyphRange[3] = { 0x20, 0xFFFF, 0 };
-        r.GlyphRanges = glyphRange;
-      }
-      return r;
-    };
+        config.GlyphRanges = glyphRange;
+    }
 
-    static std::map<std::string, ImFontConfig> allFontConfigs;
-    allFontConfigs[fontFilename] = makeFontConfig();
-    auto& fontConfig = allFontConfigs.at(fontFilename);
-
-    ImFont * font = ImGui::GetIO().Fonts->AddFontFromMemoryTTF(fontData.data, (int)fontData.dataSize, fontSize, &fontConfig);
+    ImFont * font = ImGui::GetIO().Fonts->AddFontFromMemoryTTF(fontData.data, (int)fontData.dataSize, fontSize, &config);
     if (font == nullptr)
         HIMG_THROW_STRING(std::string("Cannot load ") + fontFilename);
     FreeAssetFileData(&fontData);
     return font;
 }
 
-ImFont* MergeFontAwesomeToLastFont(float fontSize)
+ImFont* LoadFontTTF_WithFontAwesomeIcons(const std::string & fontFilename, float fontSize, bool useFullGlyphRange, ImFontConfig configFont, ImFontConfig configIcons)
+{
+    ImFont *font = LoadFontTTF(fontFilename, fontSize, useFullGlyphRange, configFont);
+    font = MergeFontAwesomeToLastFont(fontSize, configIcons);
+    return font;
+}
+
+ImFont* MergeFontAwesomeToLastFont(float fontSize, ImFontConfig config)
 {
     static std::string faFile = "fonts/fontawesome-webfont.ttf";
 
     AssetFileData fontData = LoadAssetFileData(faFile.c_str());
 
     static const ImWchar icon_fa_ranges[] = { ICON_MIN_FA, ICON_MAX_FA, 0 };
-    static ImFontConfig faConfig = [] {
-        ImFontConfig config;
-        config.MergeMode = true;
-        config.FontDataOwnedByAtlas = false;
-        return config;
-    }();
+    config.MergeMode = true;
+    config.FontDataOwnedByAtlas = false;
     auto font = ImGui::GetIO().Fonts->AddFontFromMemoryTTF(
-        fontData.data, (int)fontData.dataSize, fontSize, &faConfig, icon_fa_ranges);
+        fontData.data, (int)fontData.dataSize, fontSize, &config, icon_fa_ranges);
 
     if (font == nullptr)
         HIMG_THROW_STRING(std::string("Cannot load ") + faFile);
     FreeAssetFileData(&fontData);
-    return font;
-}
-
-
-ImFont* LoadFontTTF_WithFontAwesomeIcons(const std::string & fontFilename, float fontSize, bool useFullGlyphRange)
-{
-    ImFont *font = LoadFontTTF(fontFilename, fontSize, useFullGlyphRange);
-    font = MergeFontAwesomeToLastFont(fontSize);
     return font;
 }
 

--- a/src/hello_imgui/imgui_default_settings.h
+++ b/src/hello_imgui/imgui_default_settings.h
@@ -2,8 +2,9 @@
 #include <string>
 namespace HelloImGui
 {
-ImFont* LoadFontTTF(const std::string & fontFilename, float fontSize, bool useFullGlyphRange = false);
-ImFont* LoadFontTTF_WithFontAwesomeIcons(const std::string & fontFilename, float fontSize, bool useFullGlyphRange = false);
+ImFont* LoadFontTTF(const std::string & fontFilename, float fontSize, bool useFullGlyphRange = false, ImFontConfig config = ImFontConfig());
+ImFont* LoadFontTTF_WithFontAwesomeIcons(const std::string & fontFilename, float fontSize, bool useFullGlyphRange = false, ImFontConfig configFont = ImFontConfig(), ImFontConfig configIcons = ImFontConfig());
+ImFont* MergeFontAwesomeToLastFont(float fontSize, ImFontConfig config = ImFontConfig());
 
 namespace ImGuiDefaultSettings
 {


### PR DESCRIPTION
This is in response to #12.

There is now an added `ImFontConfig config` parameters to all font loading functions, which serves as a "template" for the actual config (much like how imgui does it internally too). I've also exposed `MergeFontAwesomeToLastFont` so that it's easier to use a different configuration (and size) for both icon font & regular font.

Example usage:

```cpp
auto& io = ImGui::GetIO();

ImFontConfig configIcons;
configIcons.GlyphMinAdvanceX = 18;
configIcons.GlyphMaxAdvanceX = 18;

io.FontDefault = HelloImGui::LoadFontTTF("fonts/DroidSans.ttf", 16);
HelloImGui::MergeFontAwesomeToLastFont(15, configIcons);
```

I have also removed the lambda's creating the config structures as well as the static variables intended to keep the config structures in memory as it [doesn't appear to be necessary](https://github.com/ocornut/imgui/blob/5f45047fb67c2147c6a1b1798b98d401e7998b51/imgui_draw.cpp#L2133).