### PR TITLE
Fix integer conversion warning seen on Windows MSVC

### DIFF
--- a/src/hello_imgui/internal/pnm.h
+++ b/src/hello_imgui/internal/pnm.h
@@ -1042,8 +1042,8 @@ namespace pnm
         inline std::unique_ptr<gain_base> get_gain(const std::size_t max)
         {
             if     (max == 255){return std::unique_ptr<identity>(new identity());}
-            else if(max >  255){return std::unique_ptr<reduce>  (new reduce(static_cast<std::uint8_t>(max)));}
-            else               {return std::unique_ptr<enlarge> (new enlarge(max));}
+            else if(max >  255){return std::unique_ptr<reduce>  (new reduce(max));}
+            else               {return std::unique_ptr<enlarge> (new enlarge(static_cast<std::uint8_t>(max)));}
         }
 
         namespace literals


### PR DESCRIPTION
Apologies, the warning fix earlier in pnm.h went on the wrong line - it results in a wrong cast in addition to not fixing the warning as intended.