### PR TITLE
[fix] App window forces itself to the foreground

### DIFF
--- a/src/hello_imgui/internal/backend_impls/abstract_runner.cpp
+++ b/src/hello_imgui/internal/backend_impls/abstract_runner.cpp
@@ -481,7 +481,7 @@ void AbstractRunner::CreateFramesAndRender()
     }
 
     
-    if (mIdxFrame >= 3)
+    if (mIdxFrame == 3)
     {
         if (params.appWindowParams.hidden)
             mBackendWindowHelper->HideWindow(mWindow);


### PR DESCRIPTION
[fix] Do not call ShowWindow every frame after the first 3 as it results in forcing the app window to the foreground all the time.