### PR TITLE
fix IsRegularFile and LoadAssetFileData_Impl

### DIFF
--- a/src/hello_imgui/internal/hello_imgui_assets.cpp
+++ b/src/hello_imgui/internal/hello_imgui_assets.cpp
@@ -20,6 +20,8 @@
 
 #ifdef _WIN32
 #include <direct.h>
+#include <locale>
+#include <codecvt>
 #else
 #include <unistd.h>
 #endif
@@ -28,10 +30,19 @@ namespace FileUtils
 {
     bool IsRegularFile(const std::string& filename)
     {
+#ifdef _WIN32
+        std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
+        std::wstring wide_filename = converter.from_bytes(filename);
+        auto ifs =new std::ifstream(wide_filename.c_str(), std::ios::binary | std::ios::ate);
+        bool found = (ifs != NULL);
+        if (ifs)
+            ifs->close();
+#else
         FILE *f = fopen(filename.c_str(), "r");
         bool found = (f != NULL);
         if (f)
             fclose(f);
+#endif
         return found;
     }
 
@@ -214,7 +225,13 @@ AssetFileData LoadAssetFileData_Impl(const char *assetPath)
 {
     AssetFileData r;
 
+#ifdef _WIN32
+    std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
+    std::wstring wide_assetPath = converter.from_bytes(assetPath);
+    std::ifstream ifs(wide_assetPath.c_str(), std::ios::binary | std::ios::ate);
+#else
     std::ifstream ifs(assetPath, std::ios::binary | std::ios::ate);
+#endif
     if (!ifs.good())
         return AssetFileData();
 


### PR DESCRIPTION
# Pull Request

## Description
Can't load files which its name is encode by gbk

## Change Type
- [x] Bug fix
- [x] Code refactoring

# System Information

- Operating System: Windows 11 (US Version)
- System Architecture: 64-bit
- Compiler: MinGW-w64


## What Happened?

The function `fopen` and `std::ifstream` can't work if the file name has `Chinese word` and `Japanese word`.(Debug:they will return NULL)

## Bug reproduction
### The Test ssource: [TestSrc_For_Window.zip](https://github.com/pthom/hello_imgui/files/11642513/TestSrc_For_Window.zip)
![beforeFix](https://github.com/pthom/hello_imgui/assets/112557849/8cc5b65d-5fff-406a-8527-b9fd7d693033)
![afterFix](https://github.com/pthom/hello_imgui/assets/112557849/ab9d20ea-3e44-4c5f-b4d0-c9a6f50f9a37)

