### PR TITLE
Fix example ini part with open/close comments

### DIFF
--- a/src/hello_imgui/internal/hello_imgui_ini_settings.cpp
+++ b/src/hello_imgui/internal/hello_imgui_ini_settings.cpp
@@ -113,7 +113,7 @@ namespace HelloImGui
 
         std::string JoinIniParts(const IniParts& iniParts)
         {
-            std::string r = ";;; !!! This configuration is handled by HelloImGui and stores several Ini Files, separated by markers like this:\n           ;;;<<<INI_NAME>>>;;;\n\n";
+            std::string r = ";;;<<< This configuration is handled by HelloImGui and stores several Ini Files, separated by markers like this: >>>;;;\n           ;;;<<<INI_NAME>>>;;;\n\n";
             for (const auto& iniPart: iniParts.Parts)
             {
                 r += ";;;<<<" + iniPart.Name + ">>>;;;\n";


### PR DESCRIPTION
This is a solution for #61.

It updates the string to have an opening and closing comment since `;;; !!!`.

This is probably not an ideal solution as it would be read as an actual part instead of a regular comment that should be ignored but this is one solution to avoid the abort issue.