### PR TITLE
fix idling using fpsIdle == 0 in emscripten

### DIFF
--- a/src/hello_imgui/internal/backend_impls/abstract_runner.cpp
+++ b/src/hello_imgui/internal/backend_impls/abstract_runner.cpp
@@ -711,7 +711,7 @@ bool AbstractRunner::ShallIdleThisFrame_Emscripten()
     ImGuiContext& g = *GImGui;
     bool hasInputEvent =  ! g.InputEventsQueue.empty();
 
-    if (! params.fpsIdling.enableIdling)
+    if (! params.fpsIdling.enableIdling || (params.fpsIdling.fpsIdle <= 0.f) )
     {
         params.fpsIdling.isIdling = false;
         return false;


### PR DESCRIPTION
Currently, you can temporarily disable idling (e.g for a short animation) by setting fpsIdle to 0, but this didn't currently work with emscripten. This small PR fixes that so it behaves the same way in emscripten.