### PR TITLE
requestFloatBuffer option

### DIFF
--- a/src/hello_imgui/internal/backend_impls/rendering_metal.mm
+++ b/src/hello_imgui/internal/backend_impls/rendering_metal.mm
@@ -4,9 +4,26 @@
 #include <backends/imgui_impl_metal.h>
 #include "hello_imgui/hello_imgui.h"
 
+#import <Cocoa/Cocoa.h>
 
 namespace HelloImGui
 {
+    bool hasEdrSupport()
+    {
+        NSArray<NSScreen *> * screens = [NSScreen screens];
+        bool buffer_edr = false;
+
+        for (NSScreen * screen in screens) {
+            if ([screen respondsToSelector:@selector
+                        (maximumPotentialExtendedDynamicRangeColorComponentValue)]) {
+                if ([screen maximumPotentialExtendedDynamicRangeColorComponentValue] >= 2.f)
+                    buffer_edr = true;
+            }
+        }
+
+        return buffer_edr;
+    }
+
     MetalGlobals& GetMetalGlobals()
     {
         static MetalGlobals sMetalGlobals;

--- a/src/hello_imgui/internal/backend_impls/rendering_metal_glfw.mm
+++ b/src/hello_imgui/internal/backend_impls/rendering_metal_glfw.mm
@@ -44,7 +44,7 @@ namespace HelloImGui
             gMetalGlobals.caMetalLayer = [CAMetalLayer layer];
             gMetalGlobals.caMetalLayer.device = gMetalGlobals.mtlDevice;
 
-            if (rendererBackendOptions.metalOptions.fixmeDummyOptionName)
+            if (rendererBackendOptions.requestFloatBuffer)
             {
                 gMetalGlobals.caMetalLayer.pixelFormat = MTLPixelFormatRGBA16Float;
                 gMetalGlobals.caMetalLayer.wantsExtendedDynamicRangeContent = YES;

--- a/src/hello_imgui/internal/backend_impls/rendering_metal_sdl.mm
+++ b/src/hello_imgui/internal/backend_impls/rendering_metal_sdl.mm
@@ -42,7 +42,7 @@ namespace HelloImGui
             // Setup Platform/Renderer backends
             gMetalGlobals.caMetalLayer = (__bridge CAMetalLayer*)SDL_RenderGetMetalLayer(gSdlMetalGlobals.sdlRenderer);
 
-            if (rendererBackendOptions.metalOptions.fixmeDummyOptionName)
+            if (rendererBackendOptions.requestFloatBuffer)
             {
                 gMetalGlobals.caMetalLayer.pixelFormat = MTLPixelFormatRGBA16Float;
                 gMetalGlobals.caMetalLayer.wantsExtendedDynamicRangeContent = YES;

--- a/src/hello_imgui/renderer_backend_options.cpp
+++ b/src/hello_imgui/renderer_backend_options.cpp
@@ -1,0 +1,11 @@
+#include "renderer_backend_options.h"
+
+namespace HelloImGui
+{
+
+// currently, only the metal backend has support for this
+#ifndef HELLOIMGUI_HAS_METAL
+bool hasEdrSupport() { return false; }
+#endif
+
+}  // namespace HelloImGui

--- a/src/hello_imgui/renderer_backend_options.h
+++ b/src/hello_imgui/renderer_backend_options.h
@@ -1,19 +1,27 @@
 #pragma once
 
-
 namespace HelloImGui
 {
+
+/**
+    Check whether extended dynamic range (EDR), i.e. the ability to reproduce intensities exceeding the
+    standard dynamic range from 0.0-1.0, is supported.
+
+    To leverage EDR support, you will need to set `floatBuffer=true` in `RendererBackendOptions`.
+    Only the macOS Metal backend currently supports this.
+
+    \return This currently returns false on all backends except Metal, where it checks whether this is
+    supported on the current displays.
+*/
+bool hasEdrSupport();
+
 /**
  @@md#RendererBackendOptions
 
-**RendererBackendOptions** is a struct that contains options for the renderer backend (Metal, Vulkan, DirectX, ...).
- Members:
-* `metalOptions`: _MetalOptions_. Options for the Metal backend (only filled if the Metal backend is available)
-
-
-**MetalOptions** is a struct that contains options for the Metal backend.
- Members:
-* `fixmeDummyOptionName`: _bool, default=false_. Dummy option for Metal backend (to be completed)
+**RendererBackendOptions** is a struct that contains options for the renderer backend (Metal, Vulkan, DirectX,
+...). Members:
+* `requestFloatBuffer`: _bool, default=false_. Set to true to request a floating-point framebuffer.
+        Before setting this to true, first check `hasEdrSupport`
 
 
 Note: If using the Metal, Vulkan or DirectX rendering backend, you can find some interesting pointers inside
@@ -25,20 +33,10 @@ Note: If using the Metal, Vulkan or DirectX rendering backend, you can find some
 @@md
 */
 
-
-#ifdef HELLOIMGUI_HAS_METAL
-struct MetalOptions
-{
-    // to be completed
-    bool fixmeDummyOptionName = false;
-};
-#endif
-
 struct RendererBackendOptions
 {
-#ifdef HELLOIMGUI_HAS_METAL
-    MetalOptions metalOptions;
-#endif
+
+    bool requestFloatBuffer = false;
 };
 
-} // namespace HelloImGui
+}  // namespace HelloImGui

--- a/src/hello_imgui_demos/hello_imgui_demodocking/hello_imgui_demodocking.main.cpp
+++ b/src/hello_imgui_demos/hello_imgui_demodocking/hello_imgui_demodocking.main.cpp
@@ -13,6 +13,7 @@ It demonstrates how to:
 */
 
 #include "hello_imgui/hello_imgui.h"
+#include "hello_imgui/renderer_backend_options.h"
 #include "imgui.h"
 #include "misc/cpp/imgui_stdlib.h"
 #include "imgui_internal.h"
@@ -628,6 +629,13 @@ int main(int, char**)
     runnerParams.appWindowParams.borderlessMovable = true;
     runnerParams.appWindowParams.borderlessResizable = true;
     runnerParams.appWindowParams.borderlessClosable = true;
+
+    // test EDR support on macOS/Metal
+    bool requestEDR = HelloImGui::hasEdrSupport();
+    runnerParams.rendererBackendOptions.requestFloatBuffer = requestEDR;
+    HelloImGui::Log(HelloImGui::LogLevel::Info,
+                    "Creating a %s framebuffer.",
+                    requestEDR ? "floating-point precision" : "standard precision");
 
     // Load additional font
     runnerParams.callbacks.LoadAdditionalFonts = [&appState]() { LoadFonts(appState); };


### PR DESCRIPTION
This PR addresses #78.

Some notes on my proposed solution:

In user code, I personally prefer to minimize the need for `#if defined` directives to choose between various options. So, I removed the `MetalOptions` struct, and instead created a shared bool option to request a float buffer. Since even on Metal this may not always be supported (or you may not always want to create a float buffer), I also created a function to check if the system supports Edr floating point framebuffers. This returns false on all systems, except on Metal it checks the underlying system for support. If this returns true, you can set `requestFloatBuffer` to true to get an EDR-compatible framebuffer. If in the future we figure out how to do this in Vulkan, DirectX or OpenGL, we can reimplement this functon for those backends and reuse this bool option.

I made a small chance to the docking demo to do this to verify it works.

I tried to incorporate comments where I could, but beyond doxygen, I don't know the syntax of your particular documentation generation tool, so you may need to adjust.
