### PR TITLE
Fixed a bug with the google closure compiler failing when trying to c… 

### DIFF
--- a/src/hello_imgui/internal/backend_impls/abstract_runner.cpp
+++ b/src/hello_imgui/internal/backend_impls/abstract_runner.cpp
@@ -318,7 +318,7 @@ void AbstractRunner::SetupDpiAwareParams()
         #ifdef __EMSCRIPTEN__
             // Query the brower to ask for devicePixelRatio
             double windowDevicePixelRatio = EM_ASM_DOUBLE( {
-                scale = window.devicePixelRatio;
+                var scale = window.devicePixelRatio;
                 return scale;
             }
             );


### PR DESCRIPTION
…ompile this code. It failed due to scale not being defined in the JS context. Here I have added the var keyword to define it localy. #101 