### PR TITLE
Enable asset load redirection

### DIFF
--- a/src/hello_imgui/hello_imgui_assets.h
+++ b/src/hello_imgui/hello_imgui_assets.h
@@ -38,6 +38,8 @@ struct AssetFileData
 // You *have* to call FreeAssetFileData to free the memory, except if you use
 // ImGui::GetIO().Fonts->AddFontFromMemoryTTF, which will take ownership of the
 // data and free it for you.
+// This function can be redirected with setLoadAssetFileDataFunction. If not redirected,
+// it calls DefaultLoadAssetFileData.
 AssetFileData LoadAssetFileData(const char *assetPath);
 
 // FreeAssetFileData(AssetFileData *)
@@ -47,6 +49,17 @@ AssetFileData LoadAssetFileData(const char *assetPath);
 void FreeAssetFileData(AssetFileData * assetFileData);
 // @@md
 
+// Function type to redirect asset loads. Function receives a path and 
+// returns an AssetFileData structure. By default, it points to 
+// DefaultLoadAssetFileData.
+typedef AssetFileData (*LoadAssetFileDataFunc)(const char *assetPath);
+
+// Redirect asset loads to user-defined function
+void setLoadAssetFileDataFunction(LoadAssetFileDataFunc func);
+
+// This function actually performs the asset load, as described in
+// LoadAssetFileData 
+AssetFileData DefaultLoadAssetFileData(const char *assetPath);
 
 // @@md#assetFileFullPath
 

--- a/src/hello_imgui/internal/hello_imgui_assets.cpp
+++ b/src/hello_imgui/internal/hello_imgui_assets.cpp
@@ -263,7 +263,7 @@ bool AssetExists(const std::string& assetFilename)
 
 #ifdef HELLOIMGUI_USE_SDL2
 
-AssetFileData LoadAssetFileData(const char *assetPath)
+AssetFileData DefaultLoadAssetFileData(const char *assetPath)
 {
     #ifdef __ANDROID__
     {
@@ -328,7 +328,7 @@ AssetFileData LoadAssetFileData_Impl(const char *assetPath)
     }
 }
 
-AssetFileData LoadAssetFileData(const char *assetPath)
+AssetFileData DefaultLoadAssetFileData(const char *assetPath)
 {
     std::string fullPath = assetFileFullPath(assetPath);
     AssetFileData r = LoadAssetFileData_Impl(fullPath.c_str());
@@ -346,6 +346,19 @@ void FreeAssetFileData(AssetFileData * assetFileData)
 {
     free(assetFileData->data);
     assetFileData = nullptr;
+}
+
+static LoadAssetFileDataFunc loadAssetFileDataFunc = DefaultLoadAssetFileData;
+
+AssetFileData LoadAssetFileData(const char *assetPath)
+{
+    AssetFileData data = loadAssetFileDataFunc(assetPath);
+    return data;
+}
+
+void setLoadAssetFileDataFunction(LoadAssetFileDataFunc newLoadAssetFileDataFunc)
+{
+    loadAssetFileDataFunc = newLoadAssetFileDataFunc;
 }
 
 #endif // #ifdef HELLOIMGUI_USE_SDL2


### PR DESCRIPTION
This patch allows to redirect the LoadAssetFileData function, so that other resource load mechanisms can be implemented. Specifically, assets can be loaded from resource data embedded in the executable. These resources can be produced with any resource compiler, including, for example https://github.com/vector-of-bool/cmrc.

This allows to create single-file-executables in Windows and Linux with all required resources embedded in the executable.

An alternative asset load implementation could look like this:

```
#include <cmrc/cmrc.hpp> // see https://github.com/vector-of-bool/cmrc
#include "hello_imgui/hello_imgui_assets.h"

CMRC_DECLARE(myAssets); // see https://github.com/vector-of-bool/cmrc 

auto resource_fs = cmrc::myAssets::get_filesystem();

[...]

HelloImGui::AssetFileData LoadAssetFileDataFromResource_Impl(const char *assetPath)
{
    HelloImGui::AssetFileData r;

    cmrc::file assetFile = resource_fs.open(assetPath);
    const char *begin = assetFile.cbegin();
    const char *end = assetFile.cend();
    r.dataSize = end - begin;
    if (r.dataSize)
    {
        r.data = malloc(r.dataSize);
        memcpy(r.data, begin, r.dataSize);
    }
    return r;
}

HelloImGui::AssetFileData LoadAssetFileDataFromResource(const char *assetPath)
{
    // assets starting with ":/" are ALWAYS loaded from the embedded resource file system
    if (strlen(assetPath)>2 && assetPath[0]==':' && assetPath[1] == '/') {
        assetPath++;
        if (!resource_fs.exists(assetPath))
        {
            std::stringstream msg;
            msg << "LoadAssetFileDataFromResource: cannot load " << assetPath << "\n";
            HIMG_ERROR(msg.str());
            return HelloImGui::AssetFileData();
        }
        else
        {
            return LoadAssetFileDataFromResource_Impl(assetPath);
        }
    }
    else
    {
        // other assets are searched on the embedded resource file system first.
        // If not found there, they are loaded from the standard assets folder
        if (resource_fs.exists(assetPath))
        {
            return LoadAssetFileDataFromResource_Impl(assetPath);
        }
        return HelloImGui::DefaultLoadAssetFileData(assetPath);
    }
}

int main(int, char **)
{
    HelloImGui::setLoadAssetFileDataFunction(LoadAssetFileDataFromResource);

    [...]
}
```

I'm not sure about the Doxygen comments, you may want to check them.