### PR TITLE
add HELLO_IMGUI_LINK_LIBRARIES to hello_imgui_add_app.cmake

### DIFF
--- a/hello_imgui_cmake/hello_imgui_add_app.cmake
+++ b/hello_imgui_cmake/hello_imgui_add_app.cmake
@@ -140,7 +140,7 @@ function(hello_imgui_prepare_app app_name assets_location)
     hello_imgui_bundle_assets(${app_name} ${assets_location})
     hello_imgui_platform_customization(${app_name} ${assets_location})
 
-    target_link_libraries(${app_name} PRIVATE hello-imgui::hello_imgui)
+    target_link_libraries(${app_name} PRIVATE hello-imgui::hello_imgui ${HELLO_IMGUI_LINK_LIBRARIES})
 
     if (ANDROID AND HELLOIMGUI_CREATE_ANDROID_STUDIO_PROJECT)
         set(apkCMake_applicationIdUrlPart ${HELLO_IMGUI_BUNDLE_IDENTIFIER_URL_PART})


### PR DESCRIPTION
Unsure if this is an OK way to include libraries to be linked or if there is another preferred way.  Did not update the documentation as I felt it was showing the minimal needed cmake config.

Did test like this ->

```
add_library(tstlib STATIC)
target_sources(tstlib PRIVATE librarytest.cpp)

add_library(tstlib2 STATIC)
target_sources(tstlib2 PRIVATE librarytest2.cpp)

SET(HELLO_IMGUI_LINK_LIBRARIES tstlib tstlib2)
hello_imgui_add_app(hello_world main.cpp)
```

Where main.cpp calls some public methods in tstlib and tstlib2