### PR TITLE
fix build error on uwp

### DIFF
--- a/src/hello_imgui/internal/poor_man_log.cpp
+++ b/src/hello_imgui/internal/poor_man_log.cpp
@@ -18,7 +18,14 @@ void PoorManLog(const char* msg, ...)
     va_end(args);
 
 #ifdef _MSC_VER
+#if defined(WINAPI_FAMILY) && (WINAPI_FAMILY == WINAPI_FAMILY_APP)
+    wchar_t wbuffer[2000];
+    mbstowcs(wbuffer, buffer, strlen(buffer) + 1);
+    OutputDebugString(wbuffer);
     OutputDebugString(buffer);
+#else
+     OutputDebugString(buffer);
+#endif
 #else
     printf("%s", buffer);
 #endif


### PR DESCRIPTION
I am a vcpkg maintainer. When I updated hello-imgui to version 1.5.2 in vcpkg, I found the following problems when compiling under uwp.
`error C2664: 'void OutputDebugStringW(LPCWSTR)': cannot convert argument 1 from 'char [2000]' to 'LPCWSTR'`
Therefore, I added the judgment of the uwp platform and character processing in the function.
