### PR TITLE
Fix checking for alphanumeric characters using proper conversion to a void undefined behavior (and assert message with MSBuild)

### DIFF
--- a/src/hello_imgui/internal/hello_imgui_ini_settings.cpp
+++ b/src/hello_imgui/internal/hello_imgui_ini_settings.cpp
@@ -24,9 +24,10 @@ namespace HelloImGui
             std::string AlnumOrUnderscore(const std::string& s)
             {
                 std::string r;
+
                 for (char c : s)
                 {
-                    if (isalnum(c))
+                    if (isalnum(static_cast<unsigned char>(c)))
                         r += c;
                     else
                         r += "_";


### PR DESCRIPTION
Hi,

When I use font icons in the name of a dockable window, such as:

```cpp
HelloImGui::DockableWindow windows;
windows.label = U8_TO_CHAR(ICON_FA_ROCKET " Unit tests");
windows.dockSpaceName = "MAIN_SPACE";
windows.GuiFunction = [&] { GuiFunction(); };
```

This allows me to display a window tab with an icon for better readability:
![Capture d’écran 2025-01-15 140411](https://github.com/user-attachments/assets/09bb73e2-008f-4a99-af5f-aa4b113a612c)

However, closing the application triggers an assertion error (with MSBuild) related to the isalnum function (observed in debug mode). The issue seems linked to undefined behavior caused by passing a char directly to isalnum, which expects an unsigned char (or EOF) as int. 
Reference: [cppreference.com on isalnum](https://en.cppreference.com/w/cpp/string/byte/isalnum).
An example from cppreference.com suggests using ```static_cast<unsigned char>``` to pass a ```char``` from ```std::string``` to ```isalnum```.


Stack Trace :
![image](https://github.com/user-attachments/assets/4e450a13-5f86-4988-8c28-00436a988806)

Steps to Reproduce (at least with MSBuild)
1. Create a dockable window using a label containing an icon (e.g., ICON_FA_ROCKET).
2. Close the application while in debug mode.
3. Observe the assertion error from isalnum.


