### PR TITLE
override min window size for toolbars

### DIFF
--- a/src/hello_imgui/internal/docking_details.cpp
+++ b/src/hello_imgui/internal/docking_details.cpp
@@ -522,11 +522,12 @@ void DoShowToolbar(
     ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 0.0f);
     ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 0.0f);
     ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, HelloImGui::EmToVec2(windowPaddingEm));
+    ImGui::PushStyleVar(ImGuiStyleVar_WindowMinSize, ImVec2(0.f, 0.f));
     if (windowBg.w != 0.f)
         ImGui::PushStyleColor(ImGuiCol_WindowBg, windowBg);
     static bool p_open = true;
     ImGui::Begin(windowId.c_str(), &p_open, WindowFlagsNothing() | ImGuiWindowFlags_NoScrollbar);
-    ImGui::PopStyleVar(3);
+    ImGui::PopStyleVar(4);
     if (windowBg.w != 0.f)
         ImGui::PopStyleColor();
     toolbarFunction();


### PR DESCRIPTION
This PR fixes https://github.com/pthom/hello_imgui/issues/147. The issue was that toolbar windows still had a minimum window size imposed by dear imgui, which cause the position and size for the main dock space to be calculated incorrectly.

This is a simple 2-line change which simply overrides the toolbar's minimum window size.