### PR TITLE
Add ThemeChanged callback to notify after theme updates

### DIFF
--- a/src/hello_imgui/imgui_theme.h
+++ b/src/hello_imgui/imgui_theme.h
@@ -7,6 +7,9 @@
 // provided the origin of those files is stated in the copied version
 // Some themes were adapted by themes posted by ImGui users at https://github.com/ocornut/imgui/issues/707
 //
+namespace HelloImGui{
+    struct RunnerParams;
+}
 
 namespace ImGuiTheme
 {
@@ -34,7 +37,7 @@ namespace ImGuiTheme
     const char* ImGuiTheme_Name(ImGuiTheme_ theme);
     ImGuiTheme_ ImGuiTheme_FromName(const char* themeName);
     ImGuiStyle ThemeToStyle(ImGuiTheme_ theme);
-    void ApplyTheme(ImGuiTheme_ theme);
+    void ApplyTheme(ImGuiTheme_ theme, const HelloImGui::RunnerParams& params);
 
 
     struct ImGuiThemeTweaks

--- a/src/hello_imgui/impl/imgui_theme.cpp
+++ b/src/hello_imgui/impl/imgui_theme.cpp
@@ -5,6 +5,7 @@
 // Some themes were adapted by themes posted by ImGui users at https://github.com/ocornut/imgui/issues/707
 //
 #include "hello_imgui/imgui_theme.h"
+#include "hello_imgui/runner_params.h"
 #include <string>
 #include <stack>
 
@@ -980,10 +981,12 @@ namespace ImGuiTheme
         return ImGuiStyle();
     }
 
-    void ApplyTheme(ImGuiTheme_ theme)
+    void ApplyTheme(ImGuiTheme_ theme, const HelloImGui::RunnerParams& runnerParams)
     {
         ImGuiStyle style = ThemeToStyle(theme);
         ImGui::GetStyle() = style;
+        if (runnerParams.callbacks.ThemeChanged)
+            runnerParams.callbacks.ThemeChanged();
     }
 
     ImGuiStyle TweakedThemeThemeToStyle(const ImGuiTweakedTheme& tweaked_theme)

--- a/src/hello_imgui/internal/docking_details.cpp
+++ b/src/hello_imgui/internal/docking_details.cpp
@@ -81,7 +81,7 @@ void ShowThemeTweakGuiWindow_Static()
     ShowThemeTweakGuiWindow(&gShowTweakWindow);
 }
 
-void MenuTheme()
+void MenuTheme(const RunnerParams& runnerParams)
 {
     auto& tweakedTheme = HelloImGui::GetRunnerParams()->imGuiWindowParams.tweakedTheme;
 
@@ -97,7 +97,7 @@ void MenuTheme()
             if (ImGui::MenuItem(ImGuiTheme::ImGuiTheme_Name(theme), nullptr, selected))
             {
                 tweakedTheme.Theme = theme;
-                ImGuiTheme::ApplyTheme(theme);
+                ImGuiTheme::ApplyTheme(theme, runnerParams);
             }
         }
         ImGui::EndMenu();
@@ -272,7 +272,7 @@ void MenuView_Misc(RunnerParams& runnerParams)
 	}
 
     if (runnerParams.imGuiWindowParams.showMenu_View_Themes)
-        MenuTheme();
+        MenuTheme(runnerParams);
 }
 
 void ShowViewMenu(RunnerParams & runnerParams)

--- a/src/hello_imgui/internal/hello_imgui_ini_settings.cpp
+++ b/src/hello_imgui/internal/hello_imgui_ini_settings.cpp
@@ -453,7 +453,7 @@ namespace HelloImGui
             {
                 auto theme = ImGuiTheme::ImGuiTheme_FromName(themeName.c_str());
                 inOutRunnerParams->imGuiWindowParams.tweakedTheme.Theme = theme;
-                ImGuiTheme::ApplyTheme(theme);
+                ImGuiTheme::ApplyTheme(theme, *inOutRunnerParams);
             }
             HelloImGui::SwitchLayout(layoutName);
 

--- a/src/hello_imgui/runner_callbacks.h
+++ b/src/hello_imgui/runner_callbacks.h
@@ -255,6 +255,13 @@ struct RunnerCallbacks
     // after the dockable windows are rendered.
     VoidFunction PostRenderDockableWindows = EmptyVoidFunction();
 
+    // `ThemeChanged`: You can here add a function that will be called
+    //  immediately after `ImGuiTheme::ApplyTheme` has been executed. This is
+    //  typically triggered when the user clicks a theme menu item in the menubar,
+    //  allowing custom drawings or UI elements to update their colors right after
+    //  the theme change.
+    VoidFunction ThemeChanged = EmptyVoidFunction();
+
     // `AnyBackendEventCallback`:
     //  Callbacks for events from a specific backend. _Only implemented for SDL.
     //  where the event will be of type 'SDL_Event *'_


### PR DESCRIPTION
Introduce a new callback `ThemeChanged` in `runner_callbacks.h`, invoked immediately after `ImGuiTheme::ApplyTheme` completes. This enables applications to react to theme changes—typically triggered when the user selects a theme from the menubar—and update custom drawings or UI elements accordingly.

Fixes #156