### PR TITLE
Add BeforeSwap render-loop callback

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,11 @@
 *Version numbers are synced between Hello ImGui and Dear ImGui Bundle, using the scheme `major.minor.patch` where `patch = ImGui_patch × 100 + release`. For example, ImGui v1.92.6 → v1.92.600, and a bugfix release becomes v1.92.601.*
 
+# Unreleased
+
+**New Callbacks:**
+* Add `BeforeSwap` callback: called after ImGui's draw data was rendered to the 3D backend, but before the frame is swapped to the screen. Enables a final full-screen post-process pass over the whole frame (e.g. a color-management pass), which is not possible with `BeforeImGuiRender` (too early: the draw data is not rendered yet) nor with `AfterSwap` (too late: the frame is already presented).
+
+
 # v1.92.700
 
 * Update ImGui to v1.92.7-docking

--- a/src/hello_imgui/internal/backend_impls/abstract_runner.cpp
+++ b/src/hello_imgui/internal/backend_impls/abstract_runner.cpp
@@ -1240,12 +1240,18 @@ void AbstractRunner::CreateFramesAndRender(bool insideReentrantCall)
     };
 
 
-    // Render and Swap
-    auto fnRenderAndSwap = [this]()
+    // Render
+    // (separate from Swap below, so that the BeforeSwap user callback can run in between,
+    //  outside of any SCOPED_RELEASE_GIL_ON_MAIN_THREAD block)
+    auto fnRender = [this]()
     {
         ImGui::Render();
         mRenderingBackendCallbacks->Impl_RenderDrawData_To_3D();
+    };
 
+    // Swap
+    auto fnSwap = [this]()
+    {
         if (ImGui::GetIO().ConfigFlags & ImGuiConfigFlags_ViewportsEnable)
             Impl_UpdateAndRenderAdditionalPlatformWindows();
 
@@ -1425,7 +1431,16 @@ void AbstractRunner::CreateFramesAndRender(bool insideReentrantCall)
 
     {
         SCOPED_RELEASE_GIL_ON_MAIN_THREAD;
-        fnRenderAndSwap();
+        fnRender();
+    }
+
+    // BeforeSwap is a user callback, so it should not be inside SCOPED_RELEASE_GIL_ON_MAIN_THREAD
+    if (params.callbacks.BeforeSwap)
+        params.callbacks.BeforeSwap();
+
+    {
+        SCOPED_RELEASE_GIL_ON_MAIN_THREAD;
+        fnSwap();
     }
 
     // AfterSwap is a user callback, so it should not be inside SCOPED_RELEASE_GIL_ON_MAIN_THREAD

--- a/src/hello_imgui/runner_callbacks.h
+++ b/src/hello_imgui/runner_callbacks.h
@@ -262,6 +262,14 @@ struct RunnerCallbacks
     //  ImGui::Render() (which will also call ImGui::EndFrame()).
     VoidFunction BeforeImGuiRender = EmptyVoidFunction();
 
+    // `BeforeSwap`: You can here add a function that will be called at each frame,
+    //  after the Gui was rendered, but before it is swapped to the screen.
+    //  This is a good place for a full-screen post-process pass over the whole frame
+    //  (for example a color management pass): unlike with AfterSwap, what you draw
+    //  here is still part of the presented frame.
+    //  Note: this concerns the main window only (not the secondary viewport windows).
+    VoidFunction BeforeSwap = EmptyVoidFunction();
+
     // `AfterSwap`: You can here add a function that will be called at each frame,
     //  after the Gui was rendered and swapped to the screen.
     VoidFunction AfterSwap = EmptyVoidFunction();


### PR DESCRIPTION
Adds `RunnerCallbacks::BeforeSwap`, called after ImGui's draw data has been rendered to the 3D backend, but before the frame is swapped to the screen.

### Why

There is currently no point in the render loop where an application can run a final full-screen pass over the *whole* frame — including ImGui's own UI — and still have the result presented:

- `BeforeImGuiRender` is too early: it runs before `ImGui::Render()` and `Impl_RenderDrawData_To_3D()`, so the draw data does not exist yet.
- `AfterSwap` is too late: the frame has already been presented. On Metal, `SwapMetalBuffers()` has additionally ended encoding, presented the drawable, committed, and released the drawable/command buffer by then.
- `CustomBackground` runs before the GUI is drawn, so it cannot see the UI.

The use case that motivated this is HDR/EDR display output in [HDRView](https://github.com/wkjarosz/hdrview): the frame is rendered into an offscreen float target in a working color space, and a final pass converts it to whatever transfer function and primaries the display actually wants. But the hook is not HDR-specific — it is the natural seat for any full-frame post-process.

### Implementation notes

`fnRenderAndSwap` is split into `fnRender` and `fnSwap`, so the new callback can be invoked between them and **outside** both `SCOPED_RELEASE_GIL_ON_MAIN_THREAD` blocks. That placement is deliberate: the file states that user callbacks must never run inside those blocks, and `BeforeImGuiRender` and `AfterSwap` are already placed outside them for the same reason.

The split is a pure refactor — same calls, same order. `SCOPED_RELEASE_GIL_ON_MAIN_THREAD` expands to nothing unless `IMGUI_TEST_ENGINE_WITH_PYTHON_GIL` is defined, so for C++ builds the generated code is unchanged.

`BeforeSwap` defaults to `EmptyVoidFunction()` (a null `std::function`), so applications that do not set it are unaffected and pay nothing per frame.

### Testing

Built and exercised on macOS, Windows, Linux/Wayland and Emscripten, via [HDRView](https://github.com/wkjarosz/hdrview), which uses it for exactly the color-management pass described above.
