### PR TITLE
Support requestFloatBuffer on the OpenGL3 + Glfw backend

### DIFF
--- a/.github/workflows/FloatBuffer.yml
+++ b/.github/workflows/FloatBuffer.yml
@@ -1,0 +1,49 @@
+name: "FloatBuffer"
+
+# Test that the GLFW_FLOATBUFFER code path (floating point framebuffer for HDR/EDR,
+# see RendererBackendOptions::requestFloatBuffer) still compiles.
+# It is guarded by #if defined(GLFW_FLOATBUFFER), which no stock Glfw release defines yet,
+# so the other CI builds compile it out. Here we build against an HDR-enabling Glfw fork
+# (https://github.com/Tom94/glfw), then check that the guarded code was compiled in.
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+
+
+jobs:
+  build:
+    name: Cpp
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: apt install xorg-dev libfreetype-dev
+        run: sudo apt-get update && sudo apt-get install -y xorg-dev libfreetype-dev
+
+      - name: Build and install a Glfw fork which defines GLFW_FLOATBUFFER
+        run: |
+          git clone https://github.com/Tom94/glfw.git glfw_fork
+          cd glfw_fork
+          git checkout 2cc924c234423f635aee654073e5bb5a216392dd
+          cmake -B build -DGLFW_BUILD_EXAMPLES=OFF -DGLFW_BUILD_TESTS=OFF -DGLFW_BUILD_DOCS=OFF \
+                -DGLFW_BUILD_WAYLAND=OFF -DCMAKE_INSTALL_PREFIX=$HOME/glfw_fork_install
+          cmake --build build -j 3
+          cmake --install build
+
+      - name: Build hello_imgui against the Glfw fork
+        run: |
+          mkdir build
+          cd build
+          cmake .. -DCMAKE_PREFIX_PATH=$HOME/glfw_fork_install \
+                -DHELLOIMGUI_DOWNLOAD_FREETYPE_IF_NEEDED=ON -DCMAKE_BUILD_TYPE=Release
+          cmake --build . -j 3
+
+      - name: Check that the GLFW_FLOATBUFFER code path was compiled in
+        run: |
+          nm $(find build -name libhello_imgui.a) | grep -q Impl_TryApplyFloatBuffer
+          echo "OK: the float buffer code path is present"

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,11 @@
 *Version numbers are synced between Hello ImGui and Dear ImGui Bundle, using the scheme `major.minor.patch` where `patch = ImGui_patch × 100 + release`. For example, ImGui v1.92.6 → v1.92.600, and a bugfix release becomes v1.92.601.*
 
+# Unreleased
+
+**RendererBackendOptions:**
+* `requestFloatBuffer` is now also supported by the OpenGL3 + Glfw backend (it used to be Metal-only), enabling HDR/EDR display output on Windows and Linux. This requires a GLFW that defines `GLFW_FLOATBUFFER` (no stock release does yet, but HDR-enabling forks such as https://github.com/Tom94/glfw do); it is silently ignored otherwise. HelloImGui now probes whether a floating point framebuffer can actually be created, and resets `requestFloatBuffer` to false if not, so applications can read the field back to know what they got.
+
+
 # v1.92.700
 
 * Update ImGui to v1.92.7-docking

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,11 +1,29 @@
 *Version numbers are synced between Hello ImGui and Dear ImGui Bundle, using the scheme `major.minor.patch` where `patch = ImGui_patch × 100 + release`. For example, ImGui v1.92.6 → v1.92.600, and a bugfix release becomes v1.92.601.*
 
-# Unreleased
+# v1.92.900
 
-**RendererBackendOptions:**
-* `requestFloatBuffer` is now also supported by the OpenGL3 + Glfw backend (it used to be Metal-only), enabling HDR/EDR display output on Windows and Linux. This requires a GLFW that defines `GLFW_FLOATBUFFER` (no stock release does yet, but HDR-enabling forks such as https://github.com/Tom94/glfw do); it is silently ignored otherwise. HelloImGui now probes whether a floating point framebuffer can actually be created, and resets `requestFloatBuffer` to false if not, so applications can read the field back to know what they got.
+* Update ImGui to v1.92.9b-docking
+
 **New Callbacks:**
 * Add `BeforeSwap` callback: called after ImGui's draw data was rendered to the 3D backend, but before the frame is swapped to the screen. Enables a final full-screen post-process pass over the whole frame (e.g. a color-management pass), which is not possible with `BeforeImGuiRender` (too early: the draw data is not rendered yet) nor with `AfterSwap` (too late: the frame is already presented).
+* Add `ConfirmExit` callback: called when the user requests to close the app window (window close button, Cmd-Q / Alt-F4, or the App/Quit menu). Return false to cancel the exit, e.g. to confirm quitting when there are unsaved changes.
+
+**RendererBackendOptions:**
+* `requestFloatBuffer` is now also supported by the OpenGL3 + Glfw backend (it used to be Metal-only), enabling HDR/EDR display output on Windows and Linux. This requires a GLFW that defines `GLFW_FLOATBUFFER` (no stock release does yet, but HDR-enabling forks such as https://github.com/Tom94/glfw do); it is silently ignored otherwise. HelloImGui now probes whether a floating point framebuffer can actually be created, and resets `requestFloatBuffer` to false if not, so applications can read the field back to know what they got. See the new `hello_edr_opengl` demo. Note: on macOS, EDR output still requires the Metal backend.
+
+**HighDPI:**
+* Fonts are now scaled via `style.FontScaleDpi` instead of at load time (finalizes the ImGui v1.92 transition). Breaking change: removes `FontLoadingParams::adjustSizeToDpi` and `DpiFontLoadingFactor()`
+
+**Widgets:**
+* `WidgetWithResizeHandle`: the handle color now uses `ImGuiCol_ResizeGrip` (with alphaMul=0.5)
+* `InputTextResizable`: can now be resized even inside a node (node editor)
+
+**Fixes:**
+* `AssetFileFullPath` can find files in the current folder (was broken)
+* Fix an MSVC internal compiler error on `plutovg-font.c` (compile it with /Od)
+
+**Internals:**
+* `ManualRender`: refactor behavior, simpler and closer to `ImmApp::ManualRender`
 
 
 # v1.92.700

--- a/src/hello_imgui/internal/backend_impls/runner_glfw3.cpp
+++ b/src/hello_imgui/internal/backend_impls/runner_glfw3.cpp
@@ -245,10 +245,57 @@ namespace HelloImGui
         glfwMakeContextCurrent((GLFWwindow *) mWindow); // OpenGl!
     }
 
+#if defined(GLFW_FLOATBUFFER)
+    // Request a floating point framebuffer if one can actually be obtained: probe with a throwaway
+    // window first (as QueryMaxAntiAliasingSamples does), since a failing glfwCreateWindow would
+    // otherwise abort the application. requestFloatBuffer is updated to reflect what was obtained.
+    void RunnerGlfw3::Impl_TryApplyFloatBuffer()
+    {
+        if (! params.rendererBackendOptions.requestFloatBuffer)
+            return;
+
+        auto openGlOptions = gOpenGlSetupGlfw.OpenGlOptionsWithUserSettings();
+
+        glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, openGlOptions.MajorVersion);
+        glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, openGlOptions.MinorVersion);
+        if (openGlOptions.UseCoreProfile)
+            glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+        glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);
+        glfwWindowHint(GLFW_FLOATBUFFER, GLFW_TRUE);
+        GLFWwindow* probeWindow = glfwCreateWindow(64, 32, "Probe", nullptr, nullptr);
+
+        glfwDefaultWindowHints();
+
+        if (probeWindow)
+        {
+            glfwDestroyWindow(probeWindow);
+        }
+        else
+        {
+            fprintf(stderr, "HelloImGui: could not obtain a floating point framebuffer, falling back to a standard one.\n");
+            params.rendererBackendOptions.requestFloatBuffer = false;
+        }
+    }
+#endif
+
     void RunnerGlfw3::Impl_Select_Gl_Version()
     {
+#if defined(GLFW_FLOATBUFFER)
+        // Before SelectOpenGlVersion(): the probe resets the window hints when it is done.
+        Impl_TryApplyFloatBuffer();
+#else
+        // This version of Glfw cannot provide a floating point framebuffer
+        params.rendererBackendOptions.requestFloatBuffer = false;
+#endif
+
         auto openGlOptions = gOpenGlSetupGlfw.OpenGlOptionsWithUserSettings();
         gOpenGlSetupGlfw.SelectOpenGlVersion(openGlOptions);
+
+#if defined(GLFW_FLOATBUFFER)
+        // After SelectOpenGlVersion(): it may itself create a temporary window.
+        if (params.rendererBackendOptions.requestFloatBuffer)
+            glfwWindowHint(GLFW_FLOATBUFFER, GLFW_TRUE);
+#endif
     }
 
     std::string RunnerGlfw3::Impl_GlslVersion() const

--- a/src/hello_imgui/internal/backend_impls/runner_glfw3.h
+++ b/src/hello_imgui/internal/backend_impls/runner_glfw3.h
@@ -38,6 +38,8 @@ class RunnerGlfw3 : public AbstractRunner
             std::string Impl_GlslVersion() const override;
             void Impl_CreateGlContext() override;
             void Impl_InitGlLoader() override;
+        private:
+            void Impl_TryApplyFloatBuffer();
         #endif
 };
 

--- a/src/hello_imgui/internal/backend_impls/runner_glfw3_emscripten.cpp
+++ b/src/hello_imgui/internal/backend_impls/runner_glfw3_emscripten.cpp
@@ -48,6 +48,8 @@ namespace HelloImGui
         glfwWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_ES_API);
         // SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
 
+        // Emscripten cannot provide a floating point framebuffer
+        params.rendererBackendOptions.requestFloatBuffer = false;
     }
 
     std::string RunnerGlfw3Emscripten::Impl_GlslVersion() const

--- a/src/hello_imgui/renderer_backend_options.h
+++ b/src/hello_imgui/renderer_backend_options.h
@@ -69,11 +69,12 @@ struct OpenGlOptions
 // Check whether extended dynamic range (EDR), i.e. the ability to reproduce
 // intensities exceeding the standard dynamic range from 0.0-1.0, is supported.
 //
-// To leverage EDR support, you need to set `floatBuffer=true` in `RendererBackendOptions`.
-// Only the macOS Metal backend currently supports this.
+// To leverage EDR support, you need to set `requestFloatBuffer=true` in `RendererBackendOptions`.
 //
 // This currently returns false on all backends except Metal, where it checks whether
 // this is supported on the current displays.
+// On the other backends, a display's capabilities can only be queried once a window exists,
+// which is too late here: set `requestFloatBuffer=true` and read it back instead (see below).
 bool hasEdrSupport();
 
 
@@ -82,9 +83,15 @@ bool hasEdrSupport();
 struct RendererBackendOptions
 {
     // `requestFloatBuffer`:
-    // Set to true to request a floating-point framebuffer.
-    // Only available on Metal, if your display supports it.
+    // Set to true to request a floating-point framebuffer (required for HDR/EDR output).
+    // Only available on Metal, and on OpenGL3 + Glfw if your version of Glfw defines
+    // GLFW_FLOATBUFFER (it is ignored otherwise). Ignored by the other rendering backends.
     // Before setting this to true, first check `hasEdrSupport()`
+    // Note: HelloImGui sets this back to false if the request could not be satisfied, so you
+    // can read it back once Run() has created the window, to know what you actually got.
+    //
+    // This is an advanced and experimental option: HDR display support is still evolving in the
+    // operating systems, in Glfw and in Wayland, so its behavior may have to change in the future.
     bool requestFloatBuffer = false;
 
     // `openGlOptions`:

--- a/src/hello_imgui/renderer_backend_options.h
+++ b/src/hello_imgui/renderer_backend_options.h
@@ -89,6 +89,8 @@ struct RendererBackendOptions
     // Before setting this to true, first check `hasEdrSupport()`
     // Note: HelloImGui sets this back to false if the request could not be satisfied, so you
     // can read it back once Run() has created the window, to know what you actually got.
+    // Note: on macOS, EDR output requires the Metal backend: even with a floating point
+    // framebuffer, OpenGL surfaces are composited clamped to standard range.
     //
     // This is an advanced and experimental option: HDR display support is still evolving in the
     // operating systems, in Glfw and in Wayland, so its behavior may have to change in the future.

--- a/src/hello_imgui_demos/CMakeLists.txt
+++ b/src/hello_imgui_demos/CMakeLists.txt
@@ -14,6 +14,11 @@ if(HELLOIMGUI_HAS_METAL)
     # Demo of EDR (Extended Dynamic Range) support, only for Metal
     list(APPEND subdirs hello_edr)
 endif()
+if(HELLOIMGUI_HAS_OPENGL3 AND NOT EMSCRIPTEN)
+    # Demo of EDR (Extended Dynamic Range) support, for OpenGL3 + Glfw
+    # (requires a Glfw fork which defines GLFW_FLOATBUFFER, see hello_edr_opengl.cpp)
+    list(APPEND subdirs hello_edr_opengl)
+endif()
 
 foreach(target_name ${subdirs})
     add_subdirectory(${target_name})

--- a/src/hello_imgui_demos/CMakeLists.txt
+++ b/src/hello_imgui_demos/CMakeLists.txt
@@ -14,9 +14,11 @@ if(HELLOIMGUI_HAS_METAL)
     # Demo of EDR (Extended Dynamic Range) support, only for Metal
     list(APPEND subdirs hello_edr)
 endif()
-if(HELLOIMGUI_HAS_OPENGL3 AND NOT EMSCRIPTEN)
-    # Demo of EDR (Extended Dynamic Range) support, for OpenGL3 + Glfw
-    # (requires a Glfw fork which defines GLFW_FLOATBUFFER, see hello_edr_opengl.cpp)
+if(HELLOIMGUI_HAS_OPENGL3 AND NOT EMSCRIPTEN AND NOT IOS AND NOT ANDROID
+   AND NOT HELLOIMGUI_USE_GLES3 AND NOT HELLOIMGUI_USE_GLES2)
+    # Demo of EDR (Extended Dynamic Range) support, for OpenGL3 + Glfw, desktop OpenGL only
+    # (requires a Glfw fork which defines GLFW_FLOATBUFFER, see hello_edr_opengl.cpp;
+    #  the demo queries the default framebuffer with GL_BACK_LEFT, which does not exist in GLES)
     list(APPEND subdirs hello_edr_opengl)
 endif()
 

--- a/src/hello_imgui_demos/hello_edr_opengl/CMakeLists.txt
+++ b/src/hello_imgui_demos/hello_edr_opengl/CMakeLists.txt
@@ -1,0 +1,3 @@
+if (HELLOIMGUI_HAS_OPENGL3)
+    hello_imgui_add_app(hello_edr_opengl hello_edr_opengl.cpp)
+endif()

--- a/src/hello_imgui_demos/hello_edr_opengl/hello_edr_opengl.cpp
+++ b/src/hello_imgui_demos/hello_edr_opengl/hello_edr_opengl.cpp
@@ -1,0 +1,159 @@
+// Demo of EDR (Extended Dynamic Range) support in Hello ImGui, on the OpenGL3 + Glfw backend.
+//
+// This requires a version of Glfw which defines GLFW_FLOATBUFFER (no stock Glfw release does yet;
+// HDR-enabling forks such as https://github.com/Tom94/glfw do).
+// With a stock Glfw, this demo still runs, but on a standard 8 bits framebuffer.
+//
+// Note: contrary to the Metal backend, hasEdrSupport() cannot be used here (it returns false):
+// on OpenGL, the framebuffer format is negotiated at window creation time. Instead, we set
+// requestFloatBuffer = true, and read it back after Run() has created the window.
+
+#ifdef HELLOIMGUI_HAS_OPENGL3
+#include "hello_imgui/hello_imgui.h"
+#include "hello_imgui/hello_imgui_include_opengl.h"
+#include <memory>
+#include <vector>
+
+
+struct ImageEdr
+{
+    ImageEdr(int width, int height)
+    {
+        Width = width;
+        Height = height;
+        ImageData.resize(Width * Height * 4, 0.f);
+    }
+
+    // Buffer to store the image data, as RGBA float
+    // (it will be uploaded to a GL_RGBA16F texture)
+    std::vector<float> ImageData;
+    int Width, Height;
+};
+
+
+void CreateFloatPattern(ImageEdr* imageEdr, float maxR, float maxG, float maxB)
+{
+    // TopLeft color will be (0, 0, 0)
+    // TopRight color will be (maxR, 0, 0)
+    // BottomLeft color will be (0, maxG, 0)
+    // BottomRight color will be (0, 0, maxB)
+    for (int y = 0; y < imageEdr->Height; y++)
+    {
+        float yf = (float)y / (float)imageEdr->Height;
+        for (int x = 0; x < imageEdr->Width; x++)
+        {
+            float xf = (float)x / (float)imageEdr->Width;
+            float r = xf * maxR;
+            float g = yf * maxG;
+            float b = (1.0f - xf) * maxB;
+            int index = (y * imageEdr->Width + x) * 4;
+            imageEdr->ImageData[index + 0] = r;
+            imageEdr->ImageData[index + 1] = g;
+            imageEdr->ImageData[index + 2] = b;
+            imageEdr->ImageData[index + 3] = 1.0f;
+        }
+    }
+}
+
+
+struct AppState
+{
+    float maxR = 1.0f, maxG = 1.0f, maxB = 1.0f;
+
+    ImageEdr imageEdr = ImageEdr(512, 512);
+    GLuint textureGl = 0;
+
+    // Info about the framebuffer we actually obtained
+    GLint framebufferComponentType = 0;
+    GLint framebufferRedBits = 0;
+
+    AppState()
+    {
+        glGenTextures(1, &textureGl);
+        glBindTexture(GL_TEXTURE_2D, textureGl);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+        Update();
+
+        glBindFramebuffer(GL_FRAMEBUFFER, 0);
+        glGetFramebufferAttachmentParameteriv(
+            GL_FRAMEBUFFER, GL_BACK_LEFT, GL_FRAMEBUFFER_ATTACHMENT_COMPONENT_TYPE, &framebufferComponentType);
+        glGetFramebufferAttachmentParameteriv(
+            GL_FRAMEBUFFER, GL_BACK_LEFT, GL_FRAMEBUFFER_ATTACHMENT_RED_SIZE, &framebufferRedBits);
+        printf("hello_edr_opengl: requestFloatBuffer read back as %s / framebuffer: %d bits per channel, %s\n",
+               HelloImGui::GetRunnerParams()->rendererBackendOptions.requestFloatBuffer ? "true" : "false",
+               framebufferRedBits,
+               framebufferComponentType == GL_FLOAT ? "float" : "integer");
+        fflush(stdout);
+    }
+
+    ~AppState()
+    {
+        glDeleteTextures(1, &textureGl);
+    }
+
+    void Update()
+    {
+        CreateFloatPattern(&imageEdr, maxR, maxG, maxB);
+        glBindTexture(GL_TEXTURE_2D, textureGl);
+        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA16F, imageEdr.Width, imageEdr.Height,
+                     0, GL_RGBA, GL_FLOAT, imageEdr.ImageData.data());
+    }
+
+    ImTextureID TextureID()
+    {
+        return (ImTextureID)(intptr_t)textureGl;
+    }
+};
+
+
+void Gui(AppState& appState)
+{
+    bool gotFloatBuffer = HelloImGui::GetRunnerParams()->rendererBackendOptions.requestFloatBuffer;
+    if (gotFloatBuffer)
+        ImGui::TextColored(ImVec4(0.f, 1.f, 0.f, 1.f), "Floating point framebuffer obtained!");
+    else
+        ImGui::TextColored(ImVec4(1.f, 0.5f, 0.f, 1.f), "No floating point framebuffer, using a standard one.");
+    ImGui::Text("Framebuffer: %d bits per channel, component type: %s",
+                appState.framebufferRedBits,
+                appState.framebufferComponentType == GL_FLOAT ? "float" : "integer");
+
+    ImGui::Separator();
+    ImGui::TextWrapped(
+        "The image below is a GL_RGBA16F texture, i.e. RGBA 16 bits per channel, float\n"
+        "If your screen supports EDR (Extended Dynamic Range), you can experiment with setting\n"
+        "the maxR, maxG, maxB values to values > 1.0f: they should appear brighter than white.\n");
+    bool changed = false;
+    changed |= ImGui::SliderFloat("maxR", &appState.maxR, 0.0f, 2.5f);
+    changed |= ImGui::SliderFloat("maxG", &appState.maxG, 0.0f, 2.5f);
+    changed |= ImGui::SliderFloat("maxB", &appState.maxB, 0.0f, 2.5f);
+
+    if (changed)
+        appState.Update();
+
+    ImGui::Image(appState.TextureID(), ImVec2(appState.imageEdr.Width, appState.imageEdr.Height));
+}
+
+
+int main()
+{
+    HelloImGui::RunnerParams runnerParams;
+
+    // Request a floating point framebuffer: HelloImGui will reset this to false
+    // if it cannot be obtained (we display the outcome in the GUI).
+    runnerParams.rendererBackendOptions.requestFloatBuffer = true;
+
+    // AppState can be instantiated only after OpenGL is initialized, and must be destroyed before exit
+    std::unique_ptr<AppState> appState;
+    runnerParams.callbacks.EnqueuePostInit([&]() { appState = std::make_unique<AppState>(); });
+    runnerParams.callbacks.EnqueueBeforeExit([&]() { appState.reset(); });
+
+    runnerParams.callbacks.ShowGui = [&]() { Gui(*appState); };
+    HelloImGui::Run(runnerParams);
+    return 0;
+}
+
+#else // HELLOIMGUI_HAS_OPENGL3
+#include <cstdio>
+int main() { printf("This demo requires the OpenGL3 rendering backend.\n"); return 0; }
+#endif


### PR DESCRIPTION

`RendererBackendOptions::requestFloatBuffer` is currently honored only by the Metal backend; every other backend silently ignores it. This PR implements it for OpenGL3 + Glfw, which enables HDR/EDR display output on Windows and Linux — where macOS has had it since #89. It completes the existing option rather than adding new API.

### Why OpenGL needs more machinery than Metal

On Metal the request is applied *after* the window exists: `PrepareGlfwForMetal()` / `PrepareSdlForMetal()` create a `CAMetalLayer`, set `pixelFormat = MTLPixelFormatRGBA16Float` and `wantsExtendedDynamicRangeContent`, and attach it to the window's content view — GLFW is only used to obtain the `NSWindow`. Nothing is negotiated at window-creation time and there is nothing a driver can refuse. That is also why `hasEdrSupport()` is enough there: on macOS the capability belongs to the *screens*, so it can be answered before any window exists.

With OpenGL none of that holds. The framebuffer format is part of the pixel format chosen when the context is created and cannot be changed afterwards, so it has to be requested *before* `glfwCreateWindow()`, via a window hint — and that request can genuinely be refused. On Windows and Wayland the display's HDR capabilities are also window/surface-scoped rather than screen-scoped, so there is nothing meaningful to query up front and `hasEdrSupport()` cannot help. Hence the different shape here: request, then read back what was actually obtained.

### How it works

The `GLFW_FLOATBUFFER` window hint is not (yet) in any officially released GLFW. It is provided by HDR-enabling forks, notably [Tom94/glfw](https://github.com/Tom94/glfw), which is what [tev](https://github.com/Tom94/tev) has shipped on for years to deliver HDR across macOS, Windows and Linux. So while the hint is not yet standard, the approach has been proven to work.

Accordingly, the new code is guarded by `#if defined(GLFW_FLOATBUFFER)` and **compiles out entirely against a stock GLFW**, leaving behavior byte-identical to today. I had Claude Code verify this at the object-file level: the probe function is absent from `runner_glfw3.cpp.o` in a stock-GLFW build, and present in a fork build.

Even where GLFW supports the hint, the GPU, driver or display may not offer a matching pixel format, and `glfwCreateWindow()` would then fail and abort the whole application. So the request is validated up front with a throwaway hidden window — the same approach `QueryMaxAntiAliasingSamples()` already used in `opengl_setup_glfw.cpp` — and silently falls back to a standard framebuffer when unavailable. `requestFloatBuffer` is then updated in place to reflect what was actually obtained, and I've documented both symbols accordingly.

### Scope

This PR deliberately confines itself to the Glfw + OpenGL3 path (plus the Emscripten Glfw runner). Those are the only places that now clear `requestFloatBuffer` when a float buffer cannot be provided. The other backends — SDL, Vulkan, DirectX, Null, and Glfw with a non-OpenGL renderer — continue to ignore the field exactly as before, which does mean they leave a stale `true` in `requestFloatBuffer` if an application sets it.

I kept the diff focused on one backend, but if you would rather the read-back contract held everywhere, I am happy to follow up with a separate PR that clears the field in the unsupported backends too — it just touches noticeably more files.

### An advanced / experimental option

I have added a short note to `requestFloatBuffer`, in the same spirit as the existing "use at your own risk" language on `OpenGlOptions`:

> This is an advanced and experimental option: HDR display support is still evolving in the operating systems, in Glfw and in Wayland, so its behavior may have to change in the future.

The value in merging this now is that it lets people use the HDR support that already exists in Windows and Wayland **today**, instead of waiting for official GLFW to catch up — while setting expectations that the API may need to change as things stabilize. I could enable HDR on Wayland and Windows app-side in HDRView without this PR, but it would be more brittle and would depend on undocumented behavior.

### Testing

Built and exercised on macOS, Windows and Linux/Wayland (PQ and scRGB negotiated via `wp_color_manager_v1`), plus Emscripten, via [HDRView](https://github.com/wkjarosz/hdrview). Also verified that a stock-GLFW build is unaffected.

### Demo

I did not extend `hello_edr` — it is Metal-only and builds on `StoreTextureFloat16Rgba`, so a GL version is a bigger piece of work than it looks. Happy to add one if you would like it before merging.